### PR TITLE
fix: 替换代币价格API为DexScreener，添加CORS中间件

### DIFF
--- a/cmd/filscan/filscan.go
+++ b/cmd/filscan/filscan.go
@@ -67,13 +67,13 @@ func newApp(conf *config.Config, adapter londobell.Adapter, fullApi filscan.Brow
 	chain.RegisterBaseTime(r.Epoch, r.BlockTime)
 
 	server := mix.NewServer()
-	server.RegisterAPI(server.Group("/api", func(c *gin.Context) {
+	server.RegisterAPI(server.Group("/api", _app.Cors(), func(c *gin.Context) {
 		ctx := c.Request.Context()
 		ctx = context.WithValue(ctx, "url", c.Request.URL.String()) //nolint
 		c.Request = c.Request.WithContext(ctx)
 	}), "v1", fullApi)
 
-	server.RegisterAPI(server.Group("/pro", bearer.Authentication(), wrapCustomError(), vip.AuthenticationWithVIP(db, redis)), "v1", proApi)
+	server.RegisterAPI(server.Group("/pro", _app.Cors(), bearer.Authentication(), wrapCustomError(), vip.AuthenticationWithVIP(db, redis)), "v1", proApi)
 
 	//server.RegisterAPI(server.Group("/api/cron"), "v1", cronApi)
 	return server.Engine

--- a/utils/_app/cros.go
+++ b/utils/_app/cros.go
@@ -1,7 +1,7 @@
 package _app
 
 import (
-	"github.com/gin-gonic/gin"
+	"github.com/gozelle/gin"
 	"net/http"
 )
 

--- a/utils/_ave/token_values.go
+++ b/utils/_ave/token_values.go
@@ -1,14 +1,14 @@
 package _ave
 
 import (
-	"crypto/tls"
 	"encoding/json"
 	"fmt"
-	"github.com/gozelle/logger"
 	"io"
 	"net/http"
 	"sync"
 	"time"
+
+	"github.com/gozelle/logger"
 
 	"github.com/shopspring/decimal"
 	"golang.org/x/sync/singleflight"
@@ -61,39 +61,55 @@ func init() {
 	}
 }
 
-func RefreshToken(contractID string, td time.Duration) {
-	time.Sleep(td)
-	go RefreshToken(contractID, td)
-	client := &http.Client{}
-	req, _ := http.NewRequest("GET", fmt.Sprintf("https://openapi.opencc.xyz/api/v1/tokens/%s-filecoin", contractID), nil)
-	req.Header.Set("Ave-Auth", "0x1qqgdcaf564e4bfda1c483642db72007871324gdy")
+type dexscreenerPair struct {
+	PriceUsd string `json:"priceUsd"`
+	Volume   struct {
+		H24 float64 `json:"h24"`
+	} `json:"volume"`
+}
+
+type dexscreenerResp struct {
+	Pairs []dexscreenerPair `json:"pairs"`
+}
+
+func fetchTokenPrice(contractID string) (price, vol24 decimal.Decimal) {
+	client := &http.Client{Timeout: 10 * time.Second}
+	url := fmt.Sprintf("https://api.dexscreener.com/latest/dex/token/%s", contractID)
+	req, _ := http.NewRequest("GET", url, nil)
 	resp, err := client.Do(req)
 	if err != nil {
-		log.Error(err)
+		log.Errorf("请求 token %s 价格失败: %s", contractID, err)
 		return
 	}
 	defer resp.Body.Close()
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		log.Error(err)
+		log.Errorf("读取 token %s 响应失败: %s", contractID, err)
 		return
 	}
-	A := struct {
-		Code int `json:"code"`
-		Data struct {
-			LastPrice string `json:"price"`
-			Volume    string `json:"turnover_24h"`
-		} `json:"data"`
-	}{}
-
-	err = json.Unmarshal(body, &A)
+	var r dexscreenerResp
+	err = json.Unmarshal(body, &r)
 	if err != nil {
-		log.Error(err)
+		log.Errorf("解析 token %s 价格失败: %s, body: %s",
+			contractID, err, string(body[:min(len(body), 200)]))
 		return
 	}
+	for _, pair := range r.Pairs {
+		p, _ := decimal.NewFromString(pair.PriceUsd)
+		v := decimal.NewFromFloat(pair.Volume.H24)
+		if p.GreaterThan(price) {
+			price = p
+			vol24 = v
+		}
+	}
+	return
+}
 
-	vol24, _ := decimal.NewFromString(A.Data.Volume)
-	price, _ := decimal.NewFromString(A.Data.LastPrice)
+func RefreshToken(contractID string, td time.Duration) {
+	time.Sleep(td)
+	go RefreshToken(contractID, td)
+
+	price, vol24 := fetchTokenPrice(contractID)
 	tc.Set(contractID, ExchangeInfo{
 		LatestPrice: price,
 		Vol24:       vol24,
@@ -104,51 +120,13 @@ func GetTokenExchangeInfo(contractID string) ExchangeInfo {
 	v, _, _ := singleFlight.Do(contractID, func() (interface{}, error) {
 		res := tc.Get(contractID)
 		if res == nil {
+			price, vol24 := fetchTokenPrice(contractID)
 			res = &ExchangeInfo{
-				LatestPrice: decimal.Zero,
+				LatestPrice: price,
+				Vol24:       vol24,
 			}
-			for i := 0; i < 5; i++ {
-				client := &http.Client{}
-				req, _ := http.NewRequest("GET", fmt.Sprintf("https://openapi.opencc.xyz/api/v1/tokens/%s-filecoin", contractID), nil)
-				req.Header.Set("Ave-Auth", "0x1qqgdcaf564e4bfda1c483642db72007871324gdy")
-				http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
-				resp, err := client.Do(req)
-				if err != nil {
-					log.Error(err)
-					time.Sleep(2 * time.Second)
-					continue
-				}
-				defer resp.Body.Close()
-				body, err := io.ReadAll(resp.Body)
-				if err != nil {
-					log.Error(err)
-					break
-				}
-				A := struct {
-					Code int `json:"code"`
-					Data struct {
-						LastPrice string `json:"price"`
-						Volume    string `json:"turnover_24h"`
-					} `json:"data"`
-				}{}
-
-				err = json.Unmarshal(body, &A)
-				if err != nil {
-					log.Error(err)
-					break
-				}
-
-				vol24, _ := decimal.NewFromString(A.Data.Volume)
-				price, _ := decimal.NewFromString(A.Data.LastPrice)
-				tc.Set(contractID, ExchangeInfo{
-					LatestPrice: price,
-					Vol24:       vol24,
-				}, 30*time.Minute)
-				res.LatestPrice = price
-				res.Vol24 = vol24
-				go RefreshToken(contractID, time.Minute*30)
-				break
-			}
+			tc.Set(contractID, *res, 5*time.Minute)
+			go RefreshToken(contractID, time.Minute*30)
 		}
 		return *res, nil
 	})


### PR DESCRIPTION
- 替换 opencc.xyz 为 DexScreener（免费、无需Auth、支持Filecoin链）
- 统一抽取 fetchTokenPrice 函数，减少重复代码
- API失败时缓存5分钟，避免重复请求导致504超时
- 为 /api 和 /pro 路由组添加 CORS 中间件
- 修复 _app/cros.go 中 gin 包的导入路径